### PR TITLE
Update 004_LockingPins.md

### DIFF
--- a/02_Monitor&Control/004_LockingPins.md
+++ b/02_Monitor&Control/004_LockingPins.md
@@ -1,11 +1,3 @@
-<!-- This page was reviewed and edited by Paulo Lago
-Below the descriptions of changes I suggest 
-
-Locking Pins Screen — Main View: It looks like there’s a broken link to “Balancing General View”(./024_BalancingGeneralView.md).
-The text is clear, and no further changes are required.
-Out of curiosity: is a single locking pin sufficient to prevent movement? If only one locking pin is engaged, how much freedom of movement does the TMA still have? -->
-
-
 #### Locking Pins Screen
 
 ##### Locking Pins Screen -- Main View
@@ -67,7 +59,7 @@ vertical slider.</p></td>
 </tr>
 <tr class="even">
 <td><p>4</p></td>
-<td><p>Displays the status and allows access to the screen [“Balancing General View”](./024_BalancingGeneralView.md)</p></td>
+<td><p>Displays the status and allows access to the screen <a href="./024_BalancingGeneralView.html">Balancing General View</a></p></td>
 </tr>
 <tr class="odd">
 <td><p>5</p></td>
@@ -90,27 +82,27 @@ The locking pins have 3 positions:
 - **Free**: the locking pins are completely retracted, allowing a complete and free movement of the Elevation axis.
 - **Lock**: the locking pins are completely inserted, restricting the Elevation axis movement. This restriction is both
   mechanical and electrical, as the signal from the limit switch is wired to the TMA IS disabling the Elevation axis.
-  The active "Locking Pin Safety" interlock will appear in the "INTERLOCKS" box, accompanied by the red box. 
+  The active "Locking Pin Safety" interlock will appear in the "INTERLOCKS" box, accompanied by the red box.
 - **Test**: the locking pins are at an intermediate position, at this position the elevation axis has a few degrees
   of free motion before hitting the locking pins. This position in meant just for balancing purposes, to limit the
   motion range allowed for elevation during the process.
 
 As there are just 3 possible positions for the locking pins, for motion there are just 3 buttons named accordingly, to
-move the pins to the corresponding positions. 
+move the pins to the corresponding positions.
 
 The sequence to move the locking pins from one position to another is:
 
 1. Turn *ON* power to the locking pins. The "pin status" will change from "Idle" to "Enable".
-  If an interlock is present, press *RESET ALARM*, then *ON*. 
-1. Choose *BOTH* to move both locking pins, or *+X*, *-X*, if you are only moving the locking pin in the +X or -X bracket, 
-  respectively. 
-1.  Push *FREE, TEST* or *LOCK* buttons to command to the new position. 
-1. The locking pins will take around a minute to get into the new commanded position. 
-   The display section will show the new position highlighted with the color code described above.  
-1. Turn the locking pins *OFF*. The "pin status" will return to "Idle". 
+  If an interlock is present, press *RESET ALARM*, then *ON*.
+1. Choose *BOTH* to move both locking pins, or *+X*, *-X*, if you are only moving the locking pin in the +X or -X bracket,
+  respectively.
+1. Push *FREE, TEST* or *LOCK* buttons to command to the new position.
+1. The locking pins will take around a minute to get into the new commanded position.
+   The display section will show the new position highlighted with the color code described above.
+1. Turn the locking pins *OFF*. The "pin status" will return to "Idle".
 
-The position in mm for each pin is stored as a setting and can be adjusted by a maintenance user in the EUI settings. 
-Additionally, maintenance users may see the jog buttons for adjusting these positions; other users will just see the 
+The position in mm for each pin is stored as a setting and can be adjusted by a maintenance user in the EUI settings.
+Additionally, maintenance users may see the jog buttons for adjusting these positions; other users will just see the
 *FREE*, *TEST* and *LOCK* buttons for moving the pins.
 
 ##### Locking Pins Screen -- Current Move

--- a/02_Monitor&Control/004_LockingPins.md
+++ b/02_Monitor&Control/004_LockingPins.md
@@ -1,3 +1,11 @@
+<!-- This page was reviewed and edited by Paulo Lago
+Below the descriptions of changes I suggest 
+
+Locking Pins Screen — Main View: It looks like there’s a broken link to “Balancing General View”(./024_BalancingGeneralView.md).
+The text is clear, and no further changes are required.
+Out of curiosity: is a single locking pin sufficient to prevent movement? If only one locking pin is engaged, how much freedom of movement does the TMA still have? -->
+
+
 #### Locking Pins Screen
 
 ##### Locking Pins Screen -- Main View


### PR DESCRIPTION
This page was reviewed and edited by Paulo Lago
Below the descriptions of changes I suggest 

Locking Pins Screen — Main View: It looks like there’s a broken link to “Balancing General View”(./024_BalancingGeneralView.md). The text is clear, and no further changes are required. Out of curiosity: is a single locking pin sufficient to prevent movement? If only one locking pin is engaged, how much freedom of movement does the TMA still have?